### PR TITLE
platform windows -> win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     install_requires=[
         'dbussy; sys_platform == "linux"',
         'pyobjc; sys_platform == "darwin"',
-        'pythonnet; sys_platform == "windows"',
+        'pythonnet; sys_platform == "win32"',
     ],
 )


### PR DESCRIPTION
In setup.py `install_requires`:

`sys_platform` results in "win32" when on a windows platform.
`platform_system` results in "Windows".

To keep constistent with the other platforms I changed the windows value to win32